### PR TITLE
Evaluate snr calculation method

### DIFF
--- a/main_11.py
+++ b/main_11.py
@@ -1686,10 +1686,9 @@ def create_fft_bands_snr_comparison(workbook, all_analysis_data):
             # Process leak measurements
             leak_measurements = folder_data['leak']
             for measurement in leak_measurements:
-                # Calculate SNR for each frequency band
+                # Get frequency and signal data
                 freq = measurement['frequency']
                 signal = measurement['fft_abs_min']
-                snr_values = signal / folder_noise_floor
                 
                 # Create worksheet tab name (same logic as in individual folder processing)
                 filename = measurement['filename']
@@ -1724,7 +1723,10 @@ def create_fft_bands_snr_comparison(workbook, all_analysis_data):
                     band_mask = (freq >= freq_min) & (freq <= freq_max)
                     
                     if np.any(band_mask):
-                        band_snr = np.mean(snr_values[band_mask])
+                        # Use band-averaged approach: average signal and noise separately, then divide
+                        band_signal = signal[band_mask]
+                        band_noise = folder_noise_floor[band_mask]
+                        band_snr = np.mean(band_signal) / np.mean(band_noise)
                         key = (worksheet_name, band_name)
                         folder_snr_data[folder_name][key] = band_snr
     
@@ -1975,10 +1977,9 @@ def create_snr_frequency_bands_plot(workbook, all_analysis_data):
                 
                 worksheet_name = f"{distance_part}_Leak"
                 
-                # Calculate SNR for each frequency band
+                # Get frequency and signal data for band SNR calculation
                 freq = measurement['frequency']
                 signal = measurement['fft_abs_min']
-                snr_values = signal / folder_noise_floor
                 
                 measurement_key = f"{worksheet_name}_{folder_name}"
                 if measurement_key not in plot_data:
@@ -1988,7 +1989,10 @@ def create_snr_frequency_bands_plot(workbook, all_analysis_data):
                     band_mask = (freq >= freq_min) & (freq <= freq_max)
                     
                     if np.any(band_mask):
-                        band_snr = np.mean(snr_values[band_mask])
+                        # Use band-averaged approach: average signal and noise separately, then divide
+                        band_signal = signal[band_mask]
+                        band_noise = folder_noise_floor[band_mask]
+                        band_snr = np.mean(band_signal) / np.mean(band_noise)
                         plot_data[measurement_key][band_name] = band_snr
     
     # Prepare data for Excel chart
@@ -2230,10 +2234,9 @@ def create_file_specific_fft_bands_snr_comparison(workbook, all_analysis_data):
                 # Process leak measurements
                 leak_measurements = file_data['leak']
                 for measurement in leak_measurements:
-                    # Calculate SNR for each frequency band
+                    # Get frequency and signal data
                     freq = measurement['frequency']
                     signal = measurement['fft_abs_min']
-                    snr_values = signal / file_noise_floor
                     
                     # Create worksheet tab name (same logic as in individual folder processing)
                     filename = measurement['filename']
@@ -2268,7 +2271,10 @@ def create_file_specific_fft_bands_snr_comparison(workbook, all_analysis_data):
                         band_mask = (freq >= freq_min) & (freq <= freq_max)
                         
                         if np.any(band_mask):
-                            band_snr = np.mean(snr_values[band_mask])
+                            # Use band-averaged approach: average signal and noise separately, then divide
+                            band_signal = signal[band_mask]
+                            band_noise = file_noise_floor[band_mask]
+                            band_snr = np.mean(band_signal) / np.mean(band_noise)
                             key = (worksheet_name, band_name)
                             folder_snr_data[folder_name][key] = band_snr
     
@@ -2564,10 +2570,9 @@ def create_file_specific_snr_frequency_bands_plot(workbook, all_analysis_data):
                     
                     worksheet_name = f"{distance_part}_Leak"
                     
-                    # Calculate SNR for each frequency band
+                    # Get frequency and signal data for band SNR calculation
                     freq = measurement['frequency']
                     signal = measurement['fft_abs_min']
-                    snr_values = signal / file_noise_floor
                     
                     measurement_key = f"{worksheet_name}_{folder_name}_{base_filename}"
                     if measurement_key not in plot_data:
@@ -2577,7 +2582,10 @@ def create_file_specific_snr_frequency_bands_plot(workbook, all_analysis_data):
                         band_mask = (freq >= freq_min) & (freq <= freq_max)
                         
                         if np.any(band_mask):
-                            band_snr = np.mean(snr_values[band_mask])
+                            # Use band-averaged approach: average signal and noise separately, then divide
+                            band_signal = signal[band_mask]
+                            band_noise = file_noise_floor[band_mask]
+                            band_snr = np.mean(band_signal) / np.mean(band_noise)
                             plot_data[measurement_key][band_name] = band_snr
     
     # Prepare data for Excel chart


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Standardize band-averaged SNR calculation in plot and report functions for consistency.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, SNR for plots was calculated by averaging per-frequency bin SNR values (`mean(signal/noise)`), which can be sensitive to low noise bins. This PR aligns the calculation with the more robust method used in the leak detection algorithm (`mean(signal)/mean(noise)`), ensuring mathematical consistency and improved stability across all band-based analyses.

---
<a href="https://cursor.com/background-agent?bcId=bc-045bed98-9dd3-420a-b811-9e5062ec0e84">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-045bed98-9dd3-420a-b811-9e5062ec0e84">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>